### PR TITLE
Update readme.md default http port

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Octoprint.
 
 ## Options:
 
-`--port` Port for HTTP (defaults to 8081)
+`--port` Port for HTTP (defaults to 8111)
 
 `--https-port` Port for HTTPS (defaults to none/off)
 


### PR DESCRIPTION
http port in bin/grid-host defaults to 8111 not 8081. Updating readme to reflect that.